### PR TITLE
feat: change factory interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Syntactic sugar functions to handle duration and dates.
 
 ```javascript
-const duration = d(2).days.plus(d(1).hour)
+const duration = d(2, "days").plus(d(1, "hour"))
 
 duration.inMinutes
 // 2940
@@ -38,14 +38,12 @@ npm install x-duration
 ```javascript
 import d from "x-duration"
 
-const duration = d(2).minutes
+const duration = d(2, "minutes")
 
 // setTimeout(..., duration.inMs)
 ```
 
 ## Documentation
-
-This library manipulates 2 kinds of objects: `XDurationFactory` and `XDuration`.
 
 ```javascript
 import d, { XDurationFactory, XDuration } from "x-duration"
@@ -55,94 +53,57 @@ import d, { XDurationFactory, XDuration } from "x-duration"
 
 ```javascript
 declare const d: {
-  // Returns a factory to create durations
-  (value: number): XDurationFactory;
+  // Factory to create durations
+  (value: number, unit: XDurationUnitInput): XDuration;
 
   // Re-wrap a duration (in milliseconds) after summing them
   sum(value: number): XDuration;
 };
 
-declare class XDurationFactory {
-  constructor(value: number);
-
-  // Returns a duration in milliseconds
-  get milliseconds(): XDuration;
-  // Alias of `milliseconds`
-  get millisecond(): XDuration;
-
-  // Returns a duration in seconds
-  get seconds(): XDuration;
-  // Alias of `seconds`
-  get second(): XDuration;
-
-  // Returns a duration in minutes
-  get minutes(): XDuration;
-  // Alias of `minutes`
-  get minute(): XDuration;
-
-  // Returns a duration in hour
-  get hour(): XDuration;
-  // Alias of `hour`
-  get hours(): XDuration;
-
-  // Returns a duration in days
-  get days(): XDuration;
-  // Alias of `days`
-  get day(): XDuration;
-
-  // Returns a duration in weeks
-  get weeks(): XDuration;
-  // Alias of `weeks`
-  get week(): XDuration;
-
-  // Returns a duration in months
-  get months(): XDuration;
-  // Alias of `months`
-  get month(): XDuration;
-
-  // Returns a duration in quarters
-  get quarters(): XDuration;
-  // Alias of `quarters`
-  get quarter(): XDuration;
-
-  // Returns a duration in years
-  get years(): XDuration;
-  // Alias of `years`
-  get year(): XDuration;
-}
+type XDurationUnitInput =
+  | "milliseconds" | "millisecond" | "ms"
+  | "seconds" | "second" | "s"
+  | "minutes" | "minute" | "m"
+  | "hours" | "hour" | "h"
+  | "days" | "day" | "D"
+  | "weeks" | "week" | "W"
+  | "months" | "month" | "M"
+  | "quarters" | "quarter" | "Q"
+  | "years" | "year" | "Y";
 ```
 
 #### Examples
 
 ```javascript
-d(10).milliseconds
-d(1).millisecond
+d(10, "milliseconds")
+d(1, "millisecond")
 
-d(10).seconds
-d(1).second
+d(10, "seconds")
+d(1, "second")
 
-d(10).minutes
-d(1).minute
+d(10, "minutes")
+d(1, "minute")
 
-d(10).hours
-d(1).hour
+d(10, "hours")
+d(1, "hour")
 
-d(10).days
-d(1).day
+d(10, "days")
+d(1, "day")
 
-d(10).weeks
-d(1).week
+d(10, "weeks")
+d(1, "week")
 
-d(10).months
-d(1).month
+d(10, "months")
+d(1, "month")
 
-d(10).quarters
-d(1).quarter
+d(10, "quarters")
+d(1, "quarter")
 
-d(10).years
-d(1).year
+d(10, "years")
+d(1, "year")
 
-d.sum(d(1).hour + d(10).minutes)
+d.sum(d(1, "hour") + d(10, "minutes"))
+d.sum(d(1, "hour") - d(10, "minutes"))
 ```
 
 ### XDuration
@@ -232,34 +193,34 @@ declare class XDuration {
 /**
  * Unit converters
  */
-d(86400000).millisecond.inDays
+d(86400000, "millisecond").inDays
 // 1
 
-d(30).seconds.inMilliseconds
+d(30, "seconds").inMilliseconds
 // 30000
 
-d(1).minute.inMilliseconds
+d(1, "minute").inMilliseconds
 // 60000
 
-d(10).minutes.inSeconds
+d(10, "minutes").inSeconds
 // 600
 
-d(1.5).hours.inMinutes
+d(1.5, "hours").inMinutes
 // 90
 
-d(1.5).days.inHours
+d(1.5, "days").inHours
 // 36
 
-d(0.5).weeks.inHours
+d(0.5, "weeks").inHours
 // 84 (3 * 24 + 12)
 
-d(0.5).months.inDays
+d(0.5, "months").inDays
 // 15
 
-d(1.5).quarters.inMonths
+d(1.5, "quarters").inMonths
 // 4.5
 
-d(1.5).years.inMonths
+d(1.5, "years").inMonths
 // 18
 ```
 
@@ -267,13 +228,13 @@ d(1.5).years.inMonths
 /**
  * Transformations
  */
-d(2).hours.plus(d(90).minutes).toObject()
+d(2, "hours").plus(d(90, "minutes")).toObject()
 // { hours: 2, minutes: 90 }
 
-d(2).hours.minus(d(90).minutes).toObject()
+d(2, "hours").minus(d(90, "minutes")).toObject()
 // { hours: 2, minutes: -90 }
 
-d(2).hours.plus(d(90).minutes).rescale().toObject()
+d(2, "hours").plus(d(90, "minutes")).rescale().toObject()
 // { hours: 3, minutes: 30 }
 ```
 
@@ -283,16 +244,16 @@ d(2).hours.plus(d(90).minutes).rescale().toObject()
  */
 // Let's say the current date is "2036-01-01 12:00:00 GMT"
 
-d(3).minutes.ago
+d(3, "minutes").ago
 // 2036-01-01T11:57:00.000Z
 
-d(2).hours.fromNow
+d(2, "hours").fromNow
 // 2036-01-01T14:00:00.000Z
 
-d(2).hours.before(new Date("2036-01-01 12:00:00 GMT"))
+d(2, "hours").before(new Date("2036-01-01 12:00:00 GMT"))
 // 2036-01-01T10:00:00.000Z
 
-d(3).minutes.after(new Date("2036-01-01 12:00:00 GMT"))
+d(3, "minutes").after(new Date("2036-01-01 12:00:00 GMT"))
 // 2036-01-01T12:03:00.000Z
 ```
 
@@ -300,7 +261,7 @@ d(3).minutes.after(new Date("2036-01-01 12:00:00 GMT"))
 /**
  * Outputs
  */
-const duration = d(2).months.plus(d(10).days).plus(d(1).minute)
+const duration = d(2, "months").plus(d(10, "days")).plus(d(1, "minute"))
 
 duration.valueOf()
 // 6048060000
@@ -320,14 +281,14 @@ duration.toObject()
 Operator overloading is not really possible in Javascript, but you can sum durations to other durations (though it has some limitations, and typescript is not really happy about it.)
 
 ```javascript
-d(2).hours + d(1).minute
+d(2, "hours") + d(1, "minute")
 // 7260000 (duration in milliseconds), so we can re-wrap it as a duration:
 
-d.sum(d(2).hours + d(1).minute).toObject()
+d.sum(d(2, "hours") + d(1, "minute")).toObject()
 // { hours: 2, minutes: 1 }
 ```
 
 ```javascript
-setTimeout(..., d(1).minute)
-// will work but it's better calling explicitly "setTimeout(..., d(1).minute.inMs)"
+setTimeout(..., d(1, "minute"))
+// will work but it's better calling explicitly "setTimeout(..., d(1, "minute").inMs)"
 ```

--- a/src/__tests__/demo.spec.ts
+++ b/src/__tests__/demo.spec.ts
@@ -2,52 +2,55 @@ import d, { XDuration } from "../index";
 
 describe("Basic usage", () => {
   test("It makes duration unit convertion more expressive", () => {
-    expect(d(86400000).millisecond.inDays).toBe(1);
-    expect(d(30).seconds.inMilliseconds).toBe(30000);
-    expect(d(1).minute.inMilliseconds).toBe(60000);
-    expect(d(10).minutes.inSeconds).toBe(600);
-    expect(d(1.5).hours.inMinutes).toBe(90);
-    expect(d(1.5).days.inHours).toBe(36);
-    expect(d(0.5).weeks.inHours).toBe(3 * 24 + 12);
-    expect(d(0.5).months.inDays).toBe(15);
-    expect(d(1.5).quarters.inMonths).toBe(4.5);
-    expect(d(1.5).years.inMonths).toBe(18);
+    expect(d(86400000, "milliseconds").inDays).toBe(1);
+    expect(d(30, "seconds").inMilliseconds).toBe(30000);
+    expect(d(1, "minute").inMilliseconds).toBe(60000);
+    expect(d(10, "minutes").inSeconds).toBe(600);
+    expect(d(1.5, "hours").inMinutes).toBe(90);
+    expect(d(1.5, "days").inHours).toBe(36);
+    expect(d(0.5, "weeks").inHours).toBe(3 * 24 + 12);
+    expect(d(0.5, "months").inDays).toBe(15);
+    expect(d(1.5, "quarters").inMonths).toBe(4.5);
+    expect(d(1.5, "years").inMonths).toBe(18);
   });
 
   test("It helps manipulating dates", () => {
     const nowSeconds = Date.now() / 1000;
 
-    expect(d(3).minutes.ago.getTime() / 1000).toBeCloseTo(nowSeconds - 180, 1);
-    expect(d(2).hours.fromNow.getTime() / 1000).toBeCloseTo(
+    expect(d(3, "minutes").ago.getTime() / 1000).toBeCloseTo(
+      nowSeconds - 180,
+      1
+    );
+    expect(d(2, "hours").fromNow.getTime() / 1000).toBeCloseTo(
       nowSeconds + 7200,
       1
     );
 
     const givenDate = new Date("2036-01-01 12:00:00");
     const givenDateSeconds = givenDate.getTime() / 1000;
-    expect(d(2).hours.before(givenDate).getTime() / 1000).toBeCloseTo(
+    expect(d(2, "hours").before(givenDate).getTime() / 1000).toBeCloseTo(
       givenDateSeconds - 7200,
       1
     );
-    expect(d(3).minutes.after(givenDate).getTime() / 1000).toBeCloseTo(
+    expect(d(3, "minutes").after(givenDate).getTime() / 1000).toBeCloseTo(
       givenDateSeconds + 180,
       1
     );
   });
 
   test("It helps manipulating durations", () => {
-    expect(d(2).hours.plus(d(1).minute).toISO()).toBe("PT2H1M");
-    expect(d(2).hours.minus(d(1).minute).toISO()).toBe("PT2H-1M");
+    expect(d(2, "hours").plus(d(1, "minute")).toISO()).toBe("PT2H1M");
+    expect(d(2, "hours").minus(d(1, "minute")).toISO()).toBe("PT2H-1M");
 
     // Rescales units to their largest representation
-    expect(d(90).minutes.rescale().toObject()).toStrictEqual({
+    expect(d(90, "minutes").rescale().toObject()).toStrictEqual({
       hours: 1,
       minutes: 30,
     });
   });
 
   test("It helps to output durations", () => {
-    const duration = d(2).months.plus(d(10).days).plus(d(1).minute);
+    const duration = d(2, "months").plus(d(10, "days")).plus(d(1, "minute"));
 
     expect(duration.toISO()).toBe("P2M10DT1M");
     expect(duration.toFormat("M S")).toBe("2 864060000");
@@ -72,7 +75,7 @@ describe("Fixes JS Date shortcomings", () => {
     );
 
     // With Luxon
-    expect(d(1).month.after(new Date("2036-01-31")).toISOString()).toBe(
+    expect(d(1, "month").after(new Date("2036-01-31")).toISOString()).toBe(
       new Date("2036-02-29").toISOString()
     );
   });
@@ -87,7 +90,7 @@ describe("Type unboxing", () => {
   test("XDuration + XDuration", () => {
     // @ts-ignore: The right-hand side of an arithmetic operation must be of type
     // 'any', 'number', 'bigint' or an enum type
-    expect(d.sum(d(2).hours - d(1).minute).toISO()).toBe("PT1H59M");
+    expect(d.sum(d(2, "hours") - d(1, "minute")).toISO()).toBe("PT1H59M");
 
     // Note: XDuration + XDuration will return a number (duration in milliseconds),
     // so we need to re-wrap it with "d.sum" (and result might differ from calling
@@ -99,7 +102,7 @@ describe("Type unboxing", () => {
     const callback = jest.fn();
 
     // @ts-ignore: Argument of type 'XDuration' is not assignable to parameter of type 'number'
-    setTimeout(callback, d(1).minute);
+    setTimeout(callback, d(1, "minute"));
 
     // Note: you can also call: setTimeout(callback, d(1).minute.inMs)
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -2,13 +2,12 @@ import d, { XDuration, XDurationFactory } from "../index";
 
 test("exports a default helper function", () => {
   expect(typeof d).toBe("function");
-  expect(d(1) instanceof XDurationFactory).toBe(true);
-  expect(d(1).second instanceof XDuration).toBe(true);
+  expect(d(1, "ms") instanceof XDuration).toBe(true);
 });
 
 test("exports XDurationFactory", () => {
   expect(typeof XDurationFactory).toBe("function");
-  expect(typeof new XDurationFactory(1)).toBe("object");
+  expect(typeof XDurationFactory(1, "ms")).toBe("object");
 });
 
 test("exports XDuration", () => {
@@ -20,14 +19,14 @@ describe("d.sum", () => {
   test("d.sum returns a duration summing the parts", () => {
     const duration = d.sum(
       // @ts-ignore
-      d(1).year +
-        d(1).month +
-        d(1).week +
-        d(1).day +
-        d(1).hour +
-        d(1).minute +
-        d(1).second +
-        d(1).millisecond
+      d(1, "year") +
+        d(1, "month") +
+        d(1, "week") +
+        d(1, "day") +
+        d(1, "hour") +
+        d(1, "minute") +
+        d(1, "second") +
+        d(1, "millisecond")
     );
     expect(duration.toObject()).toStrictEqual({
       years: 1,
@@ -44,7 +43,7 @@ describe("d.sum", () => {
   test("d.sum rescales result duration", () => {
     const duration = d.sum(
       // @ts-ignore
-      d(3).days + d(4).days
+      d(3, "days") + d(4, "days")
     );
     expect(duration.toObject()).toStrictEqual({ weeks: 1 });
   });
@@ -52,7 +51,7 @@ describe("d.sum", () => {
   test("d.sum handles subtraction", () => {
     const duration = d.sum(
       // @ts-ignore
-      d(1).week - d(3).day
+      d(1, "week") - d(3, "day")
     );
     expect(duration.toObject()).toStrictEqual({ days: 4 });
   });

--- a/src/__tests__/x-duration-factory.spec.ts
+++ b/src/__tests__/x-duration-factory.spec.ts
@@ -2,92 +2,92 @@ import { XDurationFactory } from "../x-duration-factory";
 
 describe("XDurationFactory", () => {
   test("XDurationFactory#millisecond returns a duration in milliseconds", () => {
-    const duration = new XDurationFactory(1).millisecond;
+    const duration = XDurationFactory(1, "millisecond");
     expect(duration.toObject()).toStrictEqual({ milliseconds: 1 });
   });
 
   test("XDurationFactory#milliseconds returns a duration in milliseconds", () => {
-    const duration = new XDurationFactory(2).milliseconds;
+    const duration = XDurationFactory(2, "milliseconds");
     expect(duration.toObject()).toStrictEqual({ milliseconds: 2 });
   });
 
   test("XDurationFactory#second returns a duration in seconds", () => {
-    const duration = new XDurationFactory(1).second;
+    const duration = XDurationFactory(1, "second");
     expect(duration.toObject()).toStrictEqual({ seconds: 1 });
   });
 
   test("XDurationFactory#seconds returns a duration in seconds", () => {
-    const duration = new XDurationFactory(2).seconds;
+    const duration = XDurationFactory(2, "seconds");
     expect(duration.toObject()).toStrictEqual({ seconds: 2 });
   });
 
   test("XDurationFactory#minute returns a duration in minutes", () => {
-    const duration = new XDurationFactory(1).minute;
+    const duration = XDurationFactory(1, "minute");
     expect(duration.toObject()).toStrictEqual({ minutes: 1 });
   });
 
   test("XDurationFactory#minutes returns a duration in minutes", () => {
-    const duration = new XDurationFactory(2).minutes;
+    const duration = XDurationFactory(2, "minutes");
     expect(duration.toObject()).toStrictEqual({ minutes: 2 });
   });
 
   test("XDurationFactory#hour returns a duration in hours", () => {
-    const duration = new XDurationFactory(1).hour;
+    const duration = XDurationFactory(1, "hour");
     expect(duration.toObject()).toStrictEqual({ hours: 1 });
   });
 
   test("XDurationFactory#hours returns a duration in hours", () => {
-    const duration = new XDurationFactory(2).hours;
+    const duration = XDurationFactory(2, "hours");
     expect(duration.toObject()).toStrictEqual({ hours: 2 });
   });
 
   test("XDurationFactory#day returns a duration in days", () => {
-    const duration = new XDurationFactory(1).day;
+    const duration = XDurationFactory(1, "day");
     expect(duration.toObject()).toStrictEqual({ days: 1 });
   });
 
   test("XDurationFactory#days returns a duration in days", () => {
-    const duration = new XDurationFactory(2).days;
+    const duration = XDurationFactory(2, "days");
     expect(duration.toObject()).toStrictEqual({ days: 2 });
   });
 
   test("XDurationFactory#week returns a duration in weeks", () => {
-    const duration = new XDurationFactory(1).week;
+    const duration = XDurationFactory(1, "week");
     expect(duration.toObject()).toStrictEqual({ weeks: 1 });
   });
 
   test("XDurationFactory#weeks returns a duration in weeks", () => {
-    const duration = new XDurationFactory(2).weeks;
+    const duration = XDurationFactory(2, "weeks");
     expect(duration.toObject()).toStrictEqual({ weeks: 2 });
   });
 
   test("XDurationFactory#month returns a duration in months", () => {
-    const duration = new XDurationFactory(1).month;
+    const duration = XDurationFactory(1, "month");
     expect(duration.toObject()).toStrictEqual({ months: 1 });
   });
 
   test("XDurationFactory#months returns a duration in months", () => {
-    const duration = new XDurationFactory(2).months;
+    const duration = XDurationFactory(2, "months");
     expect(duration.toObject()).toStrictEqual({ months: 2 });
   });
 
   test("XDurationFactory#quarter returns a duration in quarters", () => {
-    const duration = new XDurationFactory(1).quarter;
+    const duration = XDurationFactory(1, "quarter");
     expect(duration.toObject()).toStrictEqual({ quarters: 1 });
   });
 
   test("XDurationFactory#quarters returns a duration in quarters", () => {
-    const duration = new XDurationFactory(2).quarters;
+    const duration = XDurationFactory(2, "quarters");
     expect(duration.toObject()).toStrictEqual({ quarters: 2 });
   });
 
   test("XDurationFactory#year returns a duration in years", () => {
-    const duration = new XDurationFactory(1).year;
+    const duration = XDurationFactory(1, "year");
     expect(duration.toObject()).toStrictEqual({ years: 1 });
   });
 
   test("XDurationFactory#years returns a duration in years", () => {
-    const duration = new XDurationFactory(2).years;
+    const duration = XDurationFactory(2, "years");
     expect(duration.toObject()).toStrictEqual({ years: 2 });
   });
 });

--- a/src/__tests__/x-duration.outputs.spec.ts
+++ b/src/__tests__/x-duration.outputs.spec.ts
@@ -3,14 +3,14 @@ import { XDuration } from "../x-duration";
 
 const complexDuration = d.sum(
   // @ts-ignore
-  d(1).year +
-    d(1).month +
-    d(1).week +
-    d(1).day +
-    d(1).hour +
-    d(1).minute +
-    d(1).second +
-    d(1).millisecond
+  d(1, "year") +
+    d(1, "month") +
+    d(1, "week") +
+    d(1, "day") +
+    d(1, "hour") +
+    d(1, "minute") +
+    d(1, "second") +
+    d(1, "millisecond")
 );
 
 describe("XDuration - Outputs", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import { XDuration } from "./x-duration";
-import { XDurationFactory } from "./x-duration-factory";
+import { XDurationFactory, XDurationUnitInput } from "./x-duration-factory";
 
 export { XDuration, XDurationFactory };
 
-// Returns a factory to create durations
-export const d = (value: number) => new XDurationFactory(value);
+// Factory to create durations
+export const d = (value: number, unit: XDurationUnitInput) =>
+  XDurationFactory(value, unit);
 
 // Re-wrap a duration (in milliseconds) after summing them
-d.sum = (value: number) => new XDuration({ milliseconds: value }).rescale();
+d.sum = (value: number) => XDurationFactory(value, "milliseconds").rescale();
 
 export default d;

--- a/src/x-duration-factory.ts
+++ b/src/x-duration-factory.ts
@@ -1,81 +1,30 @@
-import { XDuration } from "./x-duration";
+import { XDuration, XDurationUnit } from "./x-duration";
 
-export class XDurationFactory {
-  value: number;
+export const unitAliases = {
+  milliseconds: ["milliseconds", "millisecond", "ms"],
+  seconds: ["seconds", "second", "s"],
+  minutes: ["minutes", "minute", "m"],
+  hours: ["hours", "hour", "h"],
+  days: ["days", "day", "D"],
+  weeks: ["weeks", "week", "W"],
+  months: ["months", "month", "M"],
+  quarters: ["quarters", "quarter", "Q"],
+  years: ["years", "year", "Y"],
+} as const;
 
-  constructor(value: number) {
-    this.value = value;
-  }
+export type XDurationUnitInput = typeof unitAliases[XDurationUnit][number];
 
-  get milliseconds(): XDuration {
-    return new XDuration({ milliseconds: this.value });
-  }
+// Factory to create durations
+export const XDurationFactory = (value: number, unit: XDurationUnitInput) =>
+  new XDuration({ [reversedUnitAliases[unit]]: value });
 
-  get millisecond(): XDuration {
-    return this.milliseconds;
-  }
-
-  get seconds(): XDuration {
-    return new XDuration({ seconds: this.value });
-  }
-
-  get second(): XDuration {
-    return this.seconds;
-  }
-
-  get minutes(): XDuration {
-    return new XDuration({ minutes: this.value });
-  }
-
-  get minute(): XDuration {
-    return this.minutes;
-  }
-
-  get hour(): XDuration {
-    return this.hours;
-  }
-
-  get hours(): XDuration {
-    return new XDuration({ hours: this.value });
-  }
-
-  get days(): XDuration {
-    return new XDuration({ days: this.value });
-  }
-
-  get day(): XDuration {
-    return this.days;
-  }
-
-  get weeks(): XDuration {
-    return new XDuration({ weeks: this.value });
-  }
-
-  get week(): XDuration {
-    return this.weeks;
-  }
-
-  get months(): XDuration {
-    return new XDuration({ months: this.value });
-  }
-
-  get month(): XDuration {
-    return this.months;
-  }
-
-  get quarters(): XDuration {
-    return new XDuration({ quarters: this.value });
-  }
-
-  get quarter(): XDuration {
-    return this.quarters;
-  }
-
-  get years(): XDuration {
-    return new XDuration({ years: this.value });
-  }
-
-  get year(): XDuration {
-    return this.years;
-  }
-}
+const reversedUnitAliases = Object.entries(unitAliases).reduce(
+  (acc, [unit, aliases]) => ({
+    ...acc,
+    ...(aliases as readonly string[]).reduce(
+      (acc2, alias) => ({ ...acc2, [alias]: unit }),
+      {}
+    ),
+  }),
+  {}
+) as { [K in XDurationUnitInput]: XDurationUnit };

--- a/src/x-duration.ts
+++ b/src/x-duration.ts
@@ -1,32 +1,24 @@
 import { DateTime as LuxonDateTime, Duration as LuxonDuration } from "luxon";
 
-export type XDurationInput =
-  | { years: number }
-  | { quarters: number }
-  | { months: number }
-  | { weeks: number }
-  | { days: number }
-  | { hours: number }
-  | { minutes: number }
-  | { seconds: number }
-  | { milliseconds: number };
+export type XDurationUnit =
+  | "years"
+  | "quarters"
+  | "months"
+  | "weeks"
+  | "days"
+  | "hours"
+  | "minutes"
+  | "seconds"
+  | "milliseconds";
 
-export interface XDurationLikeObject {
-  years?: number | undefined;
-  quarters?: number | undefined;
-  months?: number | undefined;
-  weeks?: number | undefined;
-  days?: number | undefined;
-  hours?: number | undefined;
-  minutes?: number | undefined;
-  seconds?: number | undefined;
-  milliseconds?: number | undefined;
-}
+export type XDurationLikeObject = {
+  [key in XDurationUnit]?: number;
+};
 
 export class XDuration {
   #duration: LuxonDuration;
 
-  constructor(parts: XDurationInput) {
+  constructor(parts: XDurationLikeObject) {
     this.#duration = LuxonDuration.fromObject(parts);
   }
 


### PR DESCRIPTION
BREAKING CHANGE: `d(1).second` should be changed to `d(1, "second")`